### PR TITLE
feat: add CLI that converts JSONC to JSON

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,15 +25,19 @@ Keep it that way — new exported surface needs a strong justification.
 ## Layout
 
 ```
-jsoncjson.go        # the whole implementation: NewReader + token state machine
-jsoncjson_test.go   # unit tests (table-driven, stdlib testing only)
-example_test.go     # runnable godoc examples (Example_*)
-example.jsonc       # fixture used by Example_jsoncFromFile
-makefile            # lint/test targets
+jsoncjson.go              # the whole implementation: NewReader + token state machine
+jsoncjson_test.go         # unit tests (table-driven, stdlib testing only)
+example_test.go           # runnable godoc examples (Example_*)
+example.jsonc             # fixture used by Example_jsoncFromFile
+cmd/jsoncjson/main.go     # CLI: jsoncjson [-o out] [file...], stdin/stdout by default
+cmd/jsoncjson/main_test.go # CLI tests (run() is called directly, no process spawn)
+makefile                  # lint/test targets
 ```
 
-Single root package, no subpackages, no dependencies (`go.mod` has no
-`require` block).
+The library is a single root package with no dependencies (`go.mod` has no
+`require` block). `cmd/jsoncjson` is a thin main package on top of it: all the
+logic lives in `run(args, stdin, stdout, stderr) error` so it stays testable,
+and it uses only `flag` and `os` from the standard library.
 
 ## Commands
 
@@ -48,7 +52,8 @@ Go version: see `go.mod`. There is no code generation.
 
 ## Conventions
 
-- Zero dependencies: do not add any `require` to `go.mod`.
+- Zero dependencies: do not add any `require` to `go.mod`, in the library and
+  in the CLI alike.
 - The reader is streaming and allocation-light — avoid buffering the whole
   input; work byte-by-byte through the existing state machine
   (`handleToken`) in `jsoncjson.go`.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,46 @@ to a valid JSON:
 go get github.com/hedhyw/jsoncjson
 ```
 
-## Usage example:
+## CLI:
+
+Install the command:
+
+```sh
+go install github.com/hedhyw/jsoncjson/cmd/jsoncjson@latest
+```
+
+It reads JSONC and writes plain JSON. Without file arguments (or with `-`)
+the input is read from stdin, the result goes to stdout:
+
+```sh
+# From stdin.
+echo '{ "Hello": "world" /* Comment. */ }' | jsoncjson
+
+# From a file.
+jsoncjson example.jsonc
+
+# To a file.
+jsoncjson -o config.json config.jsonc
+
+# Concatenate several inputs.
+jsoncjson a.jsonc b.jsonc
+
+# Pipe it further.
+jsoncjson config.jsonc | jq .
+```
+
+Flags:
+
+| Flag       | Description                        |
+| ---------- | ---------------------------------- |
+| `-o`       | Output file, `-` for stdout.       |
+| `-version` | Print the version and exit.        |
+| `-h`       | Print the usage and exit.          |
+
+The command exits with a non-zero status and writes the reason to stderr if
+the input cannot be read or the output cannot be written.
+
+## Library usage example:
 
 More [examples](./example_test.go).
 

--- a/cmd/jsoncjson/main.go
+++ b/cmd/jsoncjson/main.go
@@ -1,0 +1,159 @@
+// Command jsoncjson reads JSONC (JSON with comments) and writes plain JSON.
+//
+// Usage:
+//
+//	jsoncjson [flags] [file...]
+//
+// With no file arguments, or with "-", the input is read from stdin. The
+// result is written to stdout, unless -o is given.
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"runtime/debug"
+
+	"github.com/hedhyw/jsoncjson"
+)
+
+const usage = `jsoncjson reads JSONC (JSON with comments) and writes plain JSON.
+
+Usage:
+  jsoncjson [flags] [file...]
+
+With no file arguments, or with "-", the input is read from stdin.
+
+Flags:
+`
+
+// version is set by the release build via -ldflags, it falls back to the
+// version recorded by the go tool.
+var version = ""
+
+func main() {
+	err := run(os.Args[1:], os.Stdin, os.Stdout, os.Stderr)
+	if err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return
+		}
+
+		fmt.Fprintln(os.Stderr, "jsoncjson:", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, stdin io.Reader, stdout, stderr io.Writer) (err error) {
+	flagSet := flag.NewFlagSet("jsoncjson", flag.ContinueOnError)
+	flagSet.SetOutput(stderr)
+	flagSet.Usage = func() {
+		_, _ = fmt.Fprint(stderr, usage)
+		flagSet.PrintDefaults()
+	}
+
+	outPath := flagSet.String("o", "-", `output file, "-" for stdout`)
+	showVersion := flagSet.Bool("version", false, "print the version and exit")
+
+	err = flagSet.Parse(args)
+	if err != nil {
+		return err
+	}
+
+	if *showVersion {
+		_, _ = fmt.Fprintln(stdout, getVersion())
+
+		return nil
+	}
+
+	out, err := openOutput(*outPath, stdout)
+	if err != nil {
+		return err
+	}
+
+	defer func() { err = errors.Join(err, out.Close()) }()
+
+	inPaths := flagSet.Args()
+	if len(inPaths) == 0 {
+		inPaths = []string{"-"}
+	}
+
+	for _, path := range inPaths {
+		err = convert(path, stdin, out)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func convert(path string, stdin io.Reader, out io.Writer) (err error) {
+	in, err := openInput(path, stdin)
+	if err != nil {
+		return err
+	}
+
+	defer func() { _ = in.Close() }()
+
+	_, err = io.Copy(out, jsoncjson.NewReader(in))
+	if err != nil {
+		return fmt.Errorf("converting %s: %w", name(path), err)
+	}
+
+	return nil
+}
+
+func openInput(path string, stdin io.Reader) (io.ReadCloser, error) {
+	if path == "-" {
+		return io.NopCloser(stdin), nil
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("opening input: %w", err)
+	}
+
+	return file, nil
+}
+
+func openOutput(path string, stdout io.Writer) (io.WriteCloser, error) {
+	if path == "-" {
+		return nopWriteCloser{Writer: stdout}, nil
+	}
+
+	file, err := os.Create(path)
+	if err != nil {
+		return nil, fmt.Errorf("creating output: %w", err)
+	}
+
+	return file, nil
+}
+
+type nopWriteCloser struct {
+	io.Writer
+}
+
+func (nopWriteCloser) Close() error { return nil }
+
+func name(path string) string {
+	if path == "-" {
+		return "stdin"
+	}
+
+	return path
+}
+
+func getVersion() string {
+	if version != "" {
+		return version
+	}
+
+	info, ok := debug.ReadBuildInfo()
+	if ok && info.Main.Version != "" {
+		return info.Main.Version
+	}
+
+	return "dev"
+}

--- a/cmd/jsoncjson/main_test.go
+++ b/cmd/jsoncjson/main_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const inputJSONC = `{
+	// Comment.
+	"Hello": "world" /* Comment. */
+}`
+
+const outputJSON = "{\n\t\t\"Hello\": \"world\" \n}"
+
+func TestRunStdin(t *testing.T) {
+	t.Parallel()
+
+	stdout := &bytes.Buffer{}
+
+	err := run(nil, strings.NewReader(inputJSONC), stdout, &bytes.Buffer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := stdout.String(); got != outputJSON {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}
+
+func TestRunFiles(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	inPath := filepath.Join(dir, "in.jsonc")
+
+	err := os.WriteFile(inPath, []byte(inputJSONC), 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stdout := &bytes.Buffer{}
+
+	err = run([]string{inPath, "-"}, strings.NewReader(inputJSONC), stdout, &bytes.Buffer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := stdout.String(); got != outputJSON+outputJSON {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}
+
+func TestRunOutputFile(t *testing.T) {
+	t.Parallel()
+
+	outPath := filepath.Join(t.TempDir(), "out.json")
+
+	err := run([]string{"-o", outPath}, strings.NewReader(inputJSONC), &bytes.Buffer{}, &bytes.Buffer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := string(data); got != outputJSON {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}
+
+func TestRunVersion(t *testing.T) {
+	t.Parallel()
+
+	stdout := &bytes.Buffer{}
+
+	err := run([]string{"-version"}, strings.NewReader(""), stdout, &bytes.Buffer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if stdout.Len() == 0 {
+		t.Fatal("version is not printed")
+	}
+}
+
+func TestRunHelp(t *testing.T) {
+	t.Parallel()
+
+	stderr := &bytes.Buffer{}
+
+	err := run([]string{"-h"}, strings.NewReader(""), &bytes.Buffer{}, stderr)
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(stderr.String(), "Usage:") {
+		t.Fatalf("unexpected usage: %q", stderr.String())
+	}
+}
+
+func TestRunMissingInput(t *testing.T) {
+	t.Parallel()
+
+	err := run([]string{"not_found.jsonc"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{})
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunBadOutput(t *testing.T) {
+	t.Parallel()
+
+	outPath := filepath.Join(t.TempDir(), "not_found", "out.json")
+
+	err := run([]string{"-o", outPath}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{})
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGetVersion(t *testing.T) {
+	t.Parallel()
+
+	if getVersion() == "" {
+		t.Fatal("version is empty")
+	}
+}

--- a/llms.txt
+++ b/llms.txt
@@ -7,15 +7,20 @@
 > JSON strings are preserved. The output can be fed straight into
 > `encoding/json`.
 
-Module: `github.com/hedhyw/jsoncjson` (Go). Single root package, no
-dependencies.
+A CLI is shipped alongside it: `go install
+github.com/hedhyw/jsoncjson/cmd/jsoncjson@latest`, then `jsoncjson [-o out]
+[file...]` — reads stdin when no file is given, writes stdout unless `-o` is
+set.
+
+Module: `github.com/hedhyw/jsoncjson` (Go). Single root package plus the
+`cmd/jsoncjson` command, no dependencies.
 
 Import path:
 - `github.com/hedhyw/jsoncjson` — `NewReader(r io.Reader) io.Reader`, the entire public API
 
 ## Docs
 
-- [README](https://github.com/hedhyw/jsoncjson/blob/master/README.md): purpose, installation, usage example
+- [README](https://github.com/hedhyw/jsoncjson/blob/master/README.md): purpose, installation, CLI and library usage
 - [AGENTS.md](https://github.com/hedhyw/jsoncjson/blob/master/AGENTS.md): guide for coding agents — API summary, layout, commands, conventions
 - [API reference](https://pkg.go.dev/github.com/hedhyw/jsoncjson): godoc with runnable examples
 - [example_test.go](https://github.com/hedhyw/jsoncjson/blob/master/example_test.go): runnable examples (decode, from bytes/string/file)

--- a/makefile
+++ b/makefile
@@ -13,11 +13,11 @@ lint: bin/golangci-lint
 .PHONY: lint
 
 test.coverage:
-	go test -v -covermode=count -coverprofile=coverage.out
+	go test -v -covermode=count -coverprofile=coverage.out ./...
 .PHONY: test.coverage
 
 test:
-	go test
+	go test ./...
 .PHONY: test
 
 bin/golangci-lint:


### PR DESCRIPTION
## Summary

- Adds a `jsoncjson` command so the library can be used straight from the shell: it reads JSONC from stdin or files and writes plain JSON to stdout or to `-o <file>`.
- Documents the command in the README, AGENTS.md and llms.txt.
- Tests now run for all packages, so the new command is covered in CI.

```mermaid
flowchart LR
    A[stdin or files] --> B[jsoncjson]
    B --> C[stdout or -o file]
```

Closes #4